### PR TITLE
78 move Available Aircraft table to component, add to Contract page

### DIFF
--- a/app/Http/Controllers/Contracts/FindContractsController.php
+++ b/app/Http/Controllers/Contracts/FindContractsController.php
@@ -3,7 +3,9 @@
 namespace App\Http\Controllers\Contracts;
 
 use App\Http\Controllers\Controller;
+use App\Models\Aircraft;
 use App\Models\Airport;
+use App\Models\Enums\AircraftStatus;
 use App\Services\Contracts\GetContractsFromCriteria;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
@@ -40,6 +42,12 @@ class FindContractsController extends Controller
 
         $contracts = $this->getContractsFromCriteria->execute($criteria);
 
-        return Inertia::render('Contracts/Contracts', ['contracts' => $contracts, 'airport' => $airport]);
+        $aircraft = Aircraft::with('fleet')
+            ->where('current_airport_id', $request->icao)
+            ->where('owner_id', 0)
+            ->where('status', AircraftStatus::ACTIVE)
+            ->get();
+
+        return Inertia::render('Contracts/Contracts', ['contracts' => $contracts, 'airport' => $airport, 'aircraft' => $aircraft]);
     }
 }

--- a/app/Http/Controllers/Contracts/ShowContractsPageController.php
+++ b/app/Http/Controllers/Contracts/ShowContractsPageController.php
@@ -3,7 +3,11 @@
 namespace App\Http\Controllers\Contracts;
 
 use App\Http\Controllers\Controller;
+use App\Models\Aircraft;
+use App\Models\Airport;
+use App\Models\Enums\AircraftStatus;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -17,6 +21,21 @@ class ShowContractsPageController extends Controller
      */
     public function __invoke(Request $request): Response
     {
-        return Inertia::render('Contracts/Contracts');
+
+        $icao = Auth::user()->current_airport_id;
+
+        $airport = Airport::where('identifier', $icao)->first();
+        if (!$airport) {
+            return Inertia::render('Contracts/Contracts')->with(['error' => 'Airport not found']);
+        }
+
+        $aircraft = Aircraft::with('fleet')
+            ->where('current_airport_id', $icao)
+            ->where('owner_id', 0)
+            ->where('status', AircraftStatus::ACTIVE)
+            ->get();
+
+        return Inertia::render('Contracts/Contracts', ['airport' => $airport, 'aircraft' => $aircraft]);
+
     }
 }

--- a/resources/js/Pages/Airports/AirportDetail.js
+++ b/resources/js/Pages/Airports/AirportDetail.js
@@ -2,23 +2,13 @@ import React, { useState } from 'react'
 import AirportMap from '../../Shared/Components/Airport/AirportMap'
 import { Link } from '@inertiajs/inertia-react'
 import AppLayout from '../../Shared/AppLayout'
+import LocalAircraftTable from '../../Shared/Components/Fleet/LocalAircraftTable'
 
 const AirportDetail = ({ airport, metar, aircraft }) => {
   const [icao, setIcao] = useState()
 
   const handleAirportChange = (e) => {
     setIcao(e.target.value)
-  }
-
-  const renderAircraftStatus = (status) => {
-    switch (status) {
-      case 1:
-        return 'Available'
-      case 2:
-        return 'Reserved'
-      case 3:
-        return 'In Use'
-    }
   }
 
   // For future use
@@ -127,29 +117,7 @@ const AirportDetail = ({ airport, metar, aircraft }) => {
             </div>
           </div>
           <div className="rounded shadow p-4 mt-2 bg-white mx-2 overflow-x-auto">
-            <div className="text-lg">Available Aircraft</div>
-            <table className="mt-2 table table-auto table-condensed">
-              <thead>
-              <tr>
-                <th>Registration</th>
-                <th>Aircraft</th>
-                <th>Hub</th>
-                <th>Fuel</th>
-                <th>Status</th>
-              </tr>
-              </thead>
-              <tbody>
-              {aircraft && aircraft.map((ac) => (
-                <tr key={ac.id}>
-                  <td><Link href={`/aircraft/${ac.id}`}>{ac.registration}</Link></td>
-                  <td>{ac.fleet.manufacturer} {ac.fleet.name} ({ac.fleet.type})</td>
-                  <td>{ac.hub_id}</td>
-                  <td>{ac.fuel_onboard.toLocaleString(navigator.language)}</td>
-                  <td>{renderAircraftStatus(ac.state)}</td>
-                </tr>
-              ))}
-              </tbody>
-            </table>
+            <LocalAircraftTable aircraftlist={aircraft} />
           </div>
         </div>
         <div className="lg:w-1/2 rounded shadow p-4 mt-2 bg-white mx-2">

--- a/resources/js/Pages/Contracts/Contracts.js
+++ b/resources/js/Pages/Contracts/Contracts.js
@@ -8,6 +8,7 @@ import { Inertia } from '@inertiajs/inertia'
 import CargoDetails from '../../Shared/Components/Contracts/CargoDetails'
 import CustomContract from '../../Shared/Components/Contracts/CustomContract'
 import AppLayout from '../../Shared/AppLayout'
+import LocalAircraftTable from '../../Shared/Components/Fleet/LocalAircraftTable'
 
 const EmptyData = (props) => {
   return (
@@ -27,7 +28,7 @@ const AirportToolTip = (props) => {
   )
 }
 
-const Contracts = ({ contracts, airport }) => {
+const Contracts = ({ contracts, airport, aircraft }) => {
   const { auth } = usePage().props
   const [selectedAirport, setSelectedAirport] = useState('')
   const [title, setTitle] = useState('Contracts')
@@ -45,11 +46,15 @@ const Contracts = ({ contracts, airport }) => {
   const [showCustom, setShowCustom] = useState(false)
 
   useEffect(() => {
-    if (contracts && airport) {
-      setTitle(`Contracts - ${airport.name} (${airport.identifier})`)
+    if (airport) {
       setSelectedAirport(airport)
+      if (contracts) {
+        setTitle(`Contracts - ${airport.name} (${airport.identifier})`)
+      } else {
+        setTitle(`Contract Search - ${airport.name} (${airport.identifier})`)
+      }
     } else {
-      setTitle('Contracts')
+      setTitle('Contract Search - Enter Airport')
     }
   }, [contracts])
 
@@ -132,6 +137,9 @@ const Contracts = ({ contracts, airport }) => {
             </div>
           </div>
           {showCustom && <CustomContract departureIcao={values.icao} hideSection={() => setShowCustom(false)} />}
+          <div className="rounded shadow p-4 mt-2 bg-white mx-2 overflow-x-auto">
+            <LocalAircraftTable aircraftlist={aircraft} />
+          </div>
           <div className="rounded shadow bg-white overflow-x-auto mt-4">
             {!airport && !contracts && <NoContent content={<EmptyData airport="" />} />}
             {airport && contracts && contracts.length === 0 && <NoContent content={<EmptyData airport={airport} />} />}

--- a/resources/js/Shared/Components/Fleet/LocalAircraftTable.js
+++ b/resources/js/Shared/Components/Fleet/LocalAircraftTable.js
@@ -1,0 +1,45 @@
+import React from 'react'
+import { Link } from '@inertiajs/inertia-react'
+
+const renderAircraftStatus = (status) => {
+  switch (status) {
+    case 1:
+      return 'Available'
+    case 2:
+      return 'Reserved'
+    case 3:
+      return 'In Use'
+  }
+}
+
+const LocalAircraftTable = (props) => {
+  return (
+      <>
+    <div className="text-lg">Aircraft at this Airport</div>
+    <table className="mt-2 table table-auto table-condensed">
+        <thead>
+        <tr>
+            <th>Registration</th>
+            <th>Aircraft</th>
+            <th>Hub</th>
+            <th>Fuel</th>
+            <th>Status</th>
+        </tr>
+        </thead>
+        <tbody>
+        {props.aircraftlist && props.aircraftlist.map((ac) => (
+            <tr key={ac.id}>
+                <td><Link href={`/aircraft/${ac.id}`}>{ac.registration}</Link></td>
+                <td>{ac.fleet.manufacturer} {ac.fleet.name} ({ac.fleet.type})</td>
+                <td>{ac.hub_id}</td>
+                <td>{ac.fuel_onboard.toLocaleString(navigator.language)}</td>
+                <td>{renderAircraftStatus(ac.state)}</td>
+            </tr>
+        ))}
+        </tbody>
+    </table>
+      </>
+  )
+}
+
+export default LocalAircraftTable


### PR DESCRIPTION
- Airport Details Page
   - Move "Available Aircraft" table on Airport Details page into shared component (Components/Fleet/LocalAircraftTable)
   - Rename "Available Aircraft" table to "Aircraft at this Airport" as it can contain aircraft with non-available status
- Contract Page
     - Add list of available aircraft using new shared component
    - Automatically load Aircraft and map using the current user location (as per default in ICAO search field)