### PR TITLE
(Re-)Add pointer cursor for tables with click handlers

### DIFF
--- a/resources/js/Pages/Contracts/Contracts.js
+++ b/resources/js/Pages/Contracts/Contracts.js
@@ -157,7 +157,7 @@ const Contracts = ({ contracts, airport }) => {
                     <tbody>
                     {contracts && contracts.map((contract) => (
                       <>
-                      <tr key={contract.id} onClick={() => updateSelectedContract(contract)} className={contract.id === selectedContract.id ? 'bg-orange-200 hover:bg-orange-100' : ''}>
+                      <tr key={contract.id} onClick={() => updateSelectedContract(contract)} className={contract.id === selectedContract.id ? 'bg-orange-200 hover:bg-orange-100 cursor-pointer' : 'cursor-pointer'}>
                         <td>
                            <Tooltip content={<AirportToolTip airport={contract.dep_airport} />} direction="right">
                             <Link href={`/airports/${contract.dep_airport_id}`}>{contract.dep_airport_id}</Link> {contract.dep_airport.longest_runway_surface === 'W' && <span className="material-icons">anchor</span>}<br/>

--- a/resources/js/Pages/Contracts/MyContracts.js
+++ b/resources/js/Pages/Contracts/MyContracts.js
@@ -76,7 +76,7 @@ const MyContracts = ({ contracts }) => {
                     <tbody>
                     {contracts && contracts.map((contract) => (
                       <>
-                      <tr key={contract.id} onClick={() => updateSelectedContract(contract)} className={contract.id === selectedContract.id ? 'bg-orange-200 hover:bg-orange-100' : ''}>
+                      <tr key={contract.id} onClick={() => updateSelectedContract(contract)} className={contract.id === selectedContract.id ? 'bg-orange-200 hover:bg-orange-100 cursor-pointer' : 'cursor-pointer'}>
                         <td>
                            <Tooltip content={<AirportToolTip airport={contract.dep_airport} />} direction="top">
                              <Link href={`/airports/${contract.dep_airport_id}`}>{contract.dep_airport_id}</Link> {contract.dep_airport.longest_runway_surface === 'W' && <span className="material-icons md-18">anchor</span>}

--- a/resources/js/Shared/Components/Dispatch/Aircraft.js
+++ b/resources/js/Shared/Components/Dispatch/Aircraft.js
@@ -31,7 +31,7 @@ const Aircraft = (props) => {
               </thead>
               <tbody>
               {props.aircraft.map((ac) => (
-                <tr key={ac.id} onClick={() => props.handleAircraftSelect(ac)} className={props.selectedAircraft.registration === ac.registration ? 'bg-orange-200 hover:bg-orange-100' : ''}>
+                <tr key={ac.id} onClick={() => props.handleAircraftSelect(ac)} className={props.selectedAircraft.registration === ac.registration ? 'bg-orange-200 hover:bg-orange-100 cursor-pointer' : 'cursor-pointer'}>
                   <td>
                     {ac.hub_id && <Link href={`/aircraft/${ac.id}`}>{ac.registration}</Link>}
                     {ac.rental_airport_id && <span>{ac.registration}</span>}


### PR DESCRIPTION
60a1869d0daf5c4c86515315115cc82b6b6c09a5 removed the pointer cursor on all tables by default. This PR re-adds it for tables that actually have a click handler on their TR element (eg, aircraft list on dispatch screen).