### PR TITLE
Bugfix: roster page sorting behavior

### DIFF
--- a/app/Http/Controllers/Crew/ShowPilotRosterController.php
+++ b/app/Http/Controllers/Crew/ShowPilotRosterController.php
@@ -34,6 +34,6 @@ class ShowPilotRosterController extends Controller
 
         return Inertia::render('Crew/Roster', ['roster' => $users->sortBy([
             [$sortBy, $direction]
-        ])]);
+        ])->values()]);
     }
 }


### PR DESCRIPTION
**Problem**: the sorting functionality on the roster page is broken, as no data is returned by inertia. This is caused by the `sortBy` method returning an object rather than a collection.

**Solution**: use the [values method](https://laravel.com/docs/10.x/collections#method-values) after sorting the users to return a new collection, instead of the nested objects.